### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ And a 'spectre':
 
 ![A ghost-like shape with curved edges](spectre-monotile.png)
 
-Each file produces a single copy of the tile. Several copies of the tile fit together to tile the plane. The 'hat' and 'turtle' monotiles only tile along with their reflections; the 'spectre' monotile tiles without reflections.
+Each file produces a single copy of the tile. Several copies of the tile fit together to tile the plane:
+
+* The 'hat' monotile can tile the plane together with its reflection.
+* The 'turtle' can tile the plane with or _without_ its reflection.
+* The 'spectre' monotile is a 'turtle' with curved edges, so that it can the tile _only_ without its reflection.
 
 The files are:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each file produces a single copy of the tile. Several copies of the tile fit tog
 
 * The 'hat' monotile can tile the plane together with its reflection.
 * The 'turtle' can tile the plane with or _without_ its reflection.
-* The 'spectre' monotile is a 'turtle' with curved edges, so that it can the tile _only_ without its reflection.
+* The 'spectre' monotile is a 'turtle' with curved edges, so that it can tile the plane _only_ without its reflection.
 
 The files are:
 


### PR DESCRIPTION
The README is inaccurate about the significance of the turtle (and therefore the spectre); it makes it sound as if the turtle is merely another tile that behaves just like the hat, which is not at the all the case. This PR, at the cost of some additional verbiage, is more accurate.